### PR TITLE
cni-plugins - fix: don't clobber on cp

### DIFF
--- a/apps/cni-plugins/Dockerfile
+++ b/apps/cni-plugins/Dockerfile
@@ -11,4 +11,4 @@ ADD https://github.com/containernetworking/plugins/releases/download/v${VERSION}
 RUN mkdir /plugins && \
       tar -zxvf /*.tgz -C /plugins && \
       rm /*.tgz
-CMD cp /plugins/* /host/opt/cni/bin
+CMD cp -n /plugins/* /host/opt/cni/bin


### PR DESCRIPTION
In more recent versions of k3s, some of the cni plugins pre-exist as symlinks to a shared cni binary (e.g. `portmap -> cni`).

```
lrwxrwxrwx 1 root root    3 Feb  9 13:04 bandwidth -> cni
lrwxrwxrwx 1 root root    3 Feb  9 13:04 bridge -> cni
-rwxr-xr-x 1 root root 4.0M Feb  6 02:58 cni
lrwxrwxrwx 1 root root    3 Feb  9 13:04 firewall -> cni
lrwxrwxrwx 1 root root    3 Feb  9 13:04 flannel -> cni
lrwxrwxrwx 1 root root    3 Feb  9 13:04 host-local -> cni
lrwxrwxrwx 1 root root    3 Feb  9 13:04 loopback -> cni
lrwxrwxrwx 1 root root    3 Feb  9 13:04 portmap -> cni
```

A plain `cp` follows the symlink and clobbers the cni binary, breaking the k3s installation.

This PR adds the `-n` flag to `cp` to avoid clobbering all together, and effectively fixes the issue.

Testing has shown that for `multus` to work, only `macvlan` and `static` need to be added. All the other pre-existing tooling suffices and does not need to be overwritten.
