### PR TITLE
Revert "Merge pull request #80 from wilfrieddaniels/patch-1"

### DIFF
--- a/apps/cni-plugins/Dockerfile
+++ b/apps/cni-plugins/Dockerfile
@@ -11,4 +11,4 @@ ADD https://github.com/containernetworking/plugins/releases/download/v${VERSION}
 RUN mkdir /plugins && \
       tar -zxvf /*.tgz -C /plugins && \
       rm /*.tgz
-CMD cp -n /plugins/* /host/opt/cni/bin
+CMD cp /plugins/* /host/opt/cni/bin


### PR DESCRIPTION
This reverts commit b912cc0186c493842f8b890f85c28d4998cbbc67, reversing changes made to 73888faf097b0023fe1baba8d36699cee148d9ce.

This broke cni-installer in my deployment (cilium + multus). I don't think -n is what we want to use here.